### PR TITLE
PR3 Harden filenames

### DIFF
--- a/src/qti2txt/builders.py
+++ b/src/qti2txt/builders.py
@@ -19,15 +19,33 @@ class QuizBuilder:
 
     # First, we will write the Title, Header, and Options to a .txt file
     def get_quiz_filename(self):
-        if "title" in self.tag_values:
-            quiz_title = self.output_dir / f"{self.tag_values['title']}".strip()
-            quiz_file_name = f"{quiz_title}.txt"
-            return quiz_file_name
-        else:
+        raw_title = self.tag_values.get("title")
+        safe_title = self.sanitize_filename_stem(raw_title)
+
+        if not raw_title:
             logger.warning(
                 "The quiz needs a title so your quiz will receive a default title."
             )
-            return "untitled_quiz.txt"
+
+        return self.output_dir / f"{safe_title}.txt"
+
+    @staticmethod
+    def sanitize_filename_stem(title):
+        """Return a safe filename stem for quiz output files."""
+        if title is None:
+            return "untitled_quiz"
+
+        # Keep visible text but remove path and platform-invalid characters.
+        safe = str(title).strip()
+        safe = re.sub(r"[\\/]+", "_", safe)
+        safe = re.sub(r"[:*?\"<>|]", "_", safe)
+        safe = re.sub(r"[\x00-\x1f\x7f]", "", safe)
+        safe = safe.strip().strip(".")
+
+        if not safe or safe in {".", ".."}:
+            return "untitled_quiz"
+
+        return safe
 
     def create_quiz_header(self):
         if "title" in self.tag_values:

--- a/src/qti2txt/builders.py
+++ b/src/qti2txt/builders.py
@@ -131,7 +131,10 @@ class QuizBuilder:
         ($IMS-CC-FILEBASE$/Images/foo.png?canvas_download=1)
         -> (web_resources/Images/foo.png)
         """
-        filebase_pattern = r"\(\$IMS-CC-FILEBASE\$/([^)]+)\)"
+        filebase_pattern = re.compile(
+            r"\((?:\$IMS-CC-FILEBASE\$|%24IMS-CC-FILEBASE%24)/([^)]+)\)",
+            flags=re.IGNORECASE,
+        )
 
         def replace_filebase_link(match):
             relative_path = match.group(1)
@@ -141,7 +144,7 @@ class QuizBuilder:
                 relative_path = f"web_resources/{relative_path}"
             return f"({relative_path})"
 
-        return re.sub(filebase_pattern, replace_filebase_link, content)
+        return filebase_pattern.sub(replace_filebase_link, content)
 
     @staticmethod
     def sanitize_markdown_links(content):

--- a/src/qti2txt/builders.py
+++ b/src/qti2txt/builders.py
@@ -34,10 +34,15 @@ class QuizBuilder:
             quiz_file_name = self.get_quiz_filename()  # returns default title if None
             with open(quiz_file_name, "w", encoding="utf-8") as f:
                 f.write(f"Quiz title: {self.tag_values['title']}\n")
-                f.write(f"Quiz description: {self.tag_values['description']}\n")
-                f.write(f"shuffle answers: {self.tag_values['shuffle_answers']}\n")
+                description = (self.tag_values.get("description") or "").strip()
+                if description:
+                    f.write(f"Quiz description: {description}\n")
                 f.write(
-                    f"show correct answers: {self.tag_values['show_correct_answers']}\n"
+                    f"shuffle answers: {self.tag_values.get('shuffle_answers', 'false')}\n"
+                )
+                f.write(
+                    "show correct answers: "
+                    f"{self.tag_values.get('show_correct_answers', 'false')}\n"
                 )
                 # TODO: Need to add if clause since one depends on the other
                 # f.write(f"one question at a time: {tag_values['one_question_at_a_time']}\n")
@@ -77,9 +82,17 @@ class QuizBuilder:
                 elif question["question_type"] == "numerical_question":
                     for answers in question["correct_answers"]:
                         if "exact" in answers and answers.get("margin", 0.0) == 0.0:
-                            f.write(f"= {answers['exact']}\n")
+                            exact = answers["exact"]
+                            if self.is_effectively_integer(exact):
+                                f.write(f"= {int(float(exact))}\n")
+                            else:
+                                f.write(f"= {self.format_number(exact)} +- 0\n")
                         elif "exact" in answers and answers.get("margin", 0.0) != 0.0:
-                            f.write(f"= {answers['exact']} +- {answers['margin']}\n")
+                            f.write(
+                                "= "
+                                f"{self.format_number(answers['exact'])} +- "
+                                f"{self.format_number(answers['margin'])}\n"
+                            )
                         elif "range" in answers:
                             f.write(f"= {answers['range']}\n")
 
@@ -110,6 +123,79 @@ class QuizBuilder:
                 if question["feedback_general"] is not None:
                     f.write(f"... {question["feedback_general"]}\n")
 
+    @staticmethod
+    def normalize_canvas_filebase_links(content):
+        """
+        Convert Canvas IMS filebase links to local paths for text2qti.
+        Example:
+        ($IMS-CC-FILEBASE$/Images/foo.png?canvas_download=1)
+        -> (web_resources/Images/foo.png)
+        """
+        filebase_pattern = r"\(\$IMS-CC-FILEBASE\$/([^)]+)\)"
+
+        def replace_filebase_link(match):
+            relative_path = match.group(1)
+            relative_path = relative_path.split("?", 1)[0]
+            relative_path = urllib.parse.unquote(relative_path).lstrip("/")
+            if not relative_path.startswith("web_resources/"):
+                relative_path = f"web_resources/{relative_path}"
+            return f"({relative_path})"
+
+        return re.sub(filebase_pattern, replace_filebase_link, content)
+
+    @staticmethod
+    def sanitize_markdown_links(content):
+        """
+        Normalize markdown links/images for text2qti:
+        - unescape escaped parentheses in URLs
+        - drop unresolved html2text placeholder links
+        """
+
+        def clean_url(url):
+            url = re.sub(r"\\+([()])", r"\1", url).strip()
+            if not url.startswith(("http://", "https://")):
+                url = url.replace("(", "%28").replace(")", "%29")
+            return url
+
+        def replace_image(match):
+            alt_text = match.group(1)
+            url = clean_url(match.group(2))
+            if url.startswith("LINK.PLACEHOLDER_"):
+                return alt_text
+            return f"![{alt_text}]({url})"
+
+        def replace_link(match):
+            link_text = match.group(1)
+            url = clean_url(match.group(2))
+            if url.startswith("LINK.PLACEHOLDER_"):
+                return link_text
+            return f"[{link_text}]({url})"
+
+        # Image links first, then normal links.
+        image_pattern = r"!\[([^\]]*)\]\(((?:\\.|[^)])+)\)"
+        link_pattern = r"(?<!!)\[([^\]]*)\]\(((?:\\.|[^)])+)\)"
+        content = re.sub(image_pattern, replace_image, content)
+        content = re.sub(link_pattern, replace_link, content)
+        return content
+
+    @staticmethod
+    def format_number(value):
+        """Render numeric values without unnecessary trailing zeros."""
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return str(value)
+        if number.is_integer():
+            return str(int(number))
+        return format(number, "g")
+
+    @staticmethod
+    def is_effectively_integer(value):
+        try:
+            return float(value).is_integer()
+        except (TypeError, ValueError):
+            return False
+
     def convert_latex_format(self):
         """Convert Canvas LaTeX image format to dollar sign LaTeX format."""
         # TODO: This isn't ideal since I'm fixing the file after it is created. Better to do this on specific chunks that would have Latex before writing it.
@@ -121,26 +207,93 @@ class QuizBuilder:
             with open(quiz_file_name, "r", encoding="utf-8") as f:
                 content = f.read()
 
-            # Pattern to match ![LaTeX: \\frac{m}{s^2}](url1)
-            latex_pattern = r"!\[LaTeX:\s*([^\]]+)\]\([^)]+\)"
-
-            def replace_latex(match):
-                latex_code = match.group(1)
-                # URL decode the LaTeX (Canvas uses double encoding)
-                latex_code = urllib.parse.unquote(latex_code)
-                latex_code = urllib.parse.unquote(latex_code)
-                # Fix double \\
-                latex_code = latex_code.replace("\\\\", "\\")
-                return f"${latex_code}$"
-
-            # Replace all LaTeX matches
-            updated_content = re.sub(latex_pattern, replace_latex, content)
+            # Replace Canvas LaTeX image markdown with inline $...$.
+            updated_content = self.replace_canvas_latex_images(content)
+            updated_content = self.normalize_canvas_filebase_links(updated_content)
+            updated_content = self.sanitize_markdown_links(updated_content)
 
             # Only rewrite if changes were made
             if updated_content != content:
                 with open(quiz_file_name, "w", encoding="utf-8") as f:
                     f.write(updated_content)
-                logger.info(f"Converted LaTeX formatting in {quiz_file_name}")
+                logger.info(
+                    f"Normalized Canvas links/LaTeX formatting in {quiz_file_name}"
+                )
 
         except Exception as e:
             logger.error(f"Error converting LaTeX format: {e}")
+
+    @staticmethod
+    def replace_canvas_latex_images(content):
+        """
+        Convert Canvas equation-image markdown entries to inline LaTeX.
+        Handles URLs with nested/escaped parentheses that regex-based matching
+        can truncate.
+        """
+        marker = "![LaTeX:"
+        output = []
+        idx = 0
+        content_len = len(content)
+
+        while True:
+            start = content.find(marker, idx)
+            if start == -1:
+                output.append(content[idx:])
+                break
+
+            output.append(content[idx:start])
+            cursor = start + len(marker)
+
+            while cursor < content_len and content[cursor].isspace():
+                cursor += 1
+
+            alt_chars = []
+            while cursor < content_len:
+                char = content[cursor]
+                if char == "\\" and cursor + 1 < content_len:
+                    alt_chars.append(char)
+                    cursor += 1
+                    alt_chars.append(content[cursor])
+                    cursor += 1
+                    continue
+                if char == "]" and cursor + 1 < content_len and content[cursor + 1] == "(":
+                    cursor += 2  # consume "]("
+                    break
+                alt_chars.append(char)
+                cursor += 1
+            else:
+                output.append(content[start:])
+                break
+
+            # Canvas equation image URLs can contain literal ')' before query
+            # args (e.g., "...)?scale=1)"). Use a delimiter-based close test.
+            found_close = False
+            while cursor < content_len:
+                char = content[cursor]
+                if char == "\\" and cursor + 1 < content_len:
+                    cursor += 2
+                    continue
+                if char == ")":
+                    next_char = content[cursor + 1] if cursor + 1 < content_len else ""
+                    if (
+                        not next_char
+                        or next_char.isspace()
+                        or next_char in ".,;:!"
+                    ):
+                        cursor += 1
+                        found_close = True
+                        break
+                cursor += 1
+
+            if not found_close:
+                output.append(content[start:])
+                break
+
+            latex_code = "".join(alt_chars).strip()
+            latex_code = urllib.parse.unquote(latex_code)
+            latex_code = urllib.parse.unquote(latex_code)
+            latex_code = latex_code.replace("\\\\", "\\")
+            output.append(f"${latex_code}$")
+            idx = cursor
+
+        return "".join(output)

--- a/src/qti2txt/helpers.py
+++ b/src/qti2txt/helpers.py
@@ -4,6 +4,11 @@ import re
 
 # Clean up HTML
 def html_to_cleantext(html_text):
+    if html_text is None:
+        return ""
+    if not isinstance(html_text, str):
+        html_text = str(html_text)
+
     h = html2text.HTML2Text()
     h.ignore_links = False
     h.body_width = 0

--- a/src/qti2txt/parsers.py
+++ b/src/qti2txt/parsers.py
@@ -31,6 +31,67 @@ class XMLCanvasParser:
             self.root = None
             raise
 
+    def _iter_selected_items(self):
+        """
+        Yield question items honoring Canvas section selection rules.
+
+        - Sections with `selection_number` export only the first N direct items.
+        - Sections without `selection_number` export all direct items.
+        """
+        if self.root is None:
+            return []
+
+        selected_items = []
+        seen_item_ids = set()
+
+        for section in self.root.findall(".//section"):
+            direct_items = section.findall("./item")
+            if not direct_items:
+                continue
+
+            selection_number = None
+            selection_text = section.findtext(
+                "./selection_ordering/selection/selection_number"
+            )
+            if selection_text:
+                try:
+                    selection_number = int(selection_text.strip())
+                except ValueError:
+                    selection_number = None
+
+            if selection_number is None:
+                items_to_include = direct_items
+            else:
+                items_to_include = direct_items[:selection_number]
+                if len(direct_items) > selection_number:
+                    logger.debug(
+                        "Section '%s' has %s items; selecting first %s based on selection_number",
+                        section.get("title") or section.get("ident") or "untitled",
+                        len(direct_items),
+                        selection_number,
+                    )
+
+            for item in items_to_include:
+                item_ident = item.get("ident")
+                if item_ident and item_ident in seen_item_ids:
+                    continue
+                if item_ident:
+                    seen_item_ids.add(item_ident)
+                selected_items.append(item)
+
+        return selected_items
+
+    @staticmethod
+    def _extract_qti_metadata(item):
+        """Collect qti metadata fields into a dictionary for one item."""
+        metadata = {}
+        for field in item.findall("./itemmetadata/qtimetadata/qtimetadatafield"):
+            label = field.findtext("fieldlabel")
+            entry = field.findtext("fieldentry")
+            if label:
+                metadata[label] = entry
+        return metadata
+
 
     #def get_feedback_general(self):
 
@@ -45,37 +106,17 @@ class XMLCanvasParser:
             logger.error("XML root is None - cannot extract question details")
             return question_details
 
-        # Go through each question and ..
-        for item in self.root.findall(".//item[@title='Question']"):
-            # get the question type
-            question_type = None
-            for question in item.findall(".//qtimetadatafield"):
-                # get fieldlabel with null check
-                fieldlabel_elem = question.find("fieldlabel")
-                fieldlabel = (
-                    fieldlabel_elem.text if fieldlabel_elem is not None else None
-                )
+        # Go through each selected question item and parse details.
+        for item in self._iter_selected_items():
+            metadata = self._extract_qti_metadata(item)
 
-                if fieldlabel == "question_type":
-                    question_type = question.find("fieldentry").text
-                    break
+            # get the question type
+            question_type = metadata.get("question_type")
+            if not question_type:
+                continue
 
             # get the points possible w/ null check
-            points_possible = None
-            for points in item.findall(".//qtimetadatafield"):
-                fieldlabel_elem = points.find("fieldlabel")
-                fieldlabel = (
-                    fieldlabel_elem.text if fieldlabel_elem is not None else None
-                )
-
-                if fieldlabel == "points_possible":
-                    points_possible_elem = points.find("fieldentry")
-                    points_possible = (
-                        points_possible_elem.text
-                        if points_possible_elem is not None
-                        else None
-                    )
-                    break
+            points_possible = metadata.get("points_possible")
             
             # get the general feedback for the question <itemfeedback ident="general_fb">
             feedback_general = None
@@ -117,27 +158,103 @@ class XMLCanvasParser:
                 choices = []
                 for response_label in item.findall(".//response_label"):
                     ident = response_label.get("ident")
-                    choice_text = response_label.find(".//mattext").text
+                    mattext_elem = response_label.find(".//mattext")
+                    choice_text = None
+                    if mattext_elem is not None:
+                        choice_text = mattext_elem.text
+                        if not choice_text:
+                            choice_text = "".join(mattext_elem.itertext()).strip()
+
+                    if not choice_text:
+                        matimage_elem = response_label.find(".//matimage")
+                        if matimage_elem is not None:
+                            choice_text = (
+                                matimage_elem.get("label")
+                                or matimage_elem.get("uri")
+                                or ""
+                            )
+
+                    if choice_text is None:
+                        logger.warning(
+                            "Missing choice text for question '%s' (item %s), response '%s'",
+                            item.get("title"),
+                            item.get("ident"),
+                            ident,
+                        )
+                        choice_text = ""
+
                     clean_choice_text = html_to_cleantext(
                         choice_text
                     )  # Clean the HTML from choice_text
+                    if not clean_choice_text.strip():
+                        logger.warning(
+                            "Empty choice text for question '%s' (item %s), response '%s'",
+                            item.get("title"),
+                            item.get("ident"),
+                            ident,
+                        )
+                        clean_choice_text = "[missing choice text]"
                     choices.append({"text": clean_choice_text, "ident": ident})
 
-                """get the correct answer via its ID. In the case of True or False, only the correct answer is supplied. In the case of multi-select, wrong answers are surrounded with a "not" tag. Check size of correct choices. If it is greater than 1, then we need to identify the wrong answer. We can do this by identifying the varequal in the NOT tag and the removing it from the correct choices list.  """
+                """
+                Determine correct answers from scoring respconditions first. Some
+                quizzes include feedback-only respconditions containing varequal
+                values that should not count as correct answers.
+                """
                 total_choices = []
                 incorrect_choices = []
                 correct_choices = []
 
-                for answer in item.iter("varequal"):
-                    total_choices.append(answer.text)
+                scoring_conditions = []
+                for respcondition in item.findall(".//respcondition"):
+                    setvar = respcondition.find(".//setvar")
+                    if setvar is None:
+                        continue
+                    setvar_text = (setvar.text or "").strip()
+                    if setvar_text:
+                        try:
+                            if float(setvar_text) <= 0:
+                                continue
+                        except ValueError:
+                            # Non-numeric setvar text is uncommon; keep it.
+                            pass
+                    scoring_conditions.append(respcondition)
+
+                condition_sources = (
+                    scoring_conditions if scoring_conditions else item.findall(".//respcondition")
+                )
+
+                for source in condition_sources:
+                    for answer in source.iter("varequal"):
+                        if answer.text:
+                            total_choices.append(answer.text.strip())
+                    for wrong_answer in source.iter("not"):
+                        wrong_varequal = wrong_answer.find(".//varequal")
+                        if (
+                            wrong_varequal is not None
+                            and wrong_varequal.text is not None
+                        ):
+                            incorrect_choices.append(wrong_varequal.text.strip())
+
                 if len(total_choices) == 1:
-                    correct_choices.append(answer.text)
+                    correct_choices.append(total_choices[0])
                 elif len(total_choices) > 1:
-                    for wrong_answer in item.iter("not"):
-                        incorrect_choices.append(wrong_answer[0].text)
-                    correct_choices = list(set(total_choices) - set(incorrect_choices))
-                else:
-                    pass
+                    incorrect_set = set(incorrect_choices)
+                    correct_choices = [
+                        ident
+                        for ident in dict.fromkeys(total_choices)
+                        if ident not in incorrect_set
+                    ]
+
+                if (
+                    question_type == "multiple_choice_question"
+                    and len(correct_choices) > 1
+                ):
+                    question_type = "multiple_answers_question"
+                    logger.warning(
+                        "Normalized question type to multiple_answers_question for item %s",
+                        item.get("ident"),
+                    )
                 logger.info("Question type: %s", question_type)
                 logger.info("Correct choices: %s", correct_choices)
 

--- a/src/qti2txt/parsers.py
+++ b/src/qti2txt/parsers.py
@@ -37,6 +37,7 @@ class XMLCanvasParser:
 
         - Sections with `selection_number` export only the first N direct items.
         - Sections without `selection_number` export all direct items.
+        - Items directly under `assessment` are always included.
         """
         if self.root is None:
             return []
@@ -72,6 +73,27 @@ class XMLCanvasParser:
                     )
 
             for item in items_to_include:
+                item_ident = item.get("ident")
+                if item_ident and item_ident in seen_item_ids:
+                    continue
+                if item_ident:
+                    seen_item_ids.add(item_ident)
+                selected_items.append(item)
+
+        # Some valid QTI exports place items directly under assessment without
+        # wrapping sections; include these too.
+        for assessment in self.root.findall(".//assessment"):
+            for item in assessment.findall("./item"):
+                item_ident = item.get("ident")
+                if item_ident and item_ident in seen_item_ids:
+                    continue
+                if item_ident:
+                    seen_item_ids.add(item_ident)
+                selected_items.append(item)
+
+        # Last-resort fallback for uncommon structures.
+        if not selected_items:
+            for item in self.root.findall(".//item"):
                 item_ident = item.get("ident")
                 if item_ident and item_ident in seen_item_ids:
                     continue

--- a/src/qti2txt/processors.py
+++ b/src/qti2txt/processors.py
@@ -38,12 +38,49 @@ class NamespaceStripper:
 
 class FileProcessor:
     @staticmethod
-    def _get_resource_file_href(resource):
-        """Return the first file href for a resource, if present."""
-        resource_file = resource.find("file")
-        if resource_file is None:
-            return None
-        return resource_file.get("href")
+    def _get_resource_file_hrefs(resource):
+        """Return all file hrefs for a resource."""
+        hrefs = []
+        for resource_file in resource.findall("file"):
+            href = resource_file.get("href")
+            if href:
+                hrefs.append(href)
+        return hrefs
+
+    @staticmethod
+    def _select_quiz_xml_href(hrefs):
+        """
+        Select the primary quiz XML href from a list of resource files.
+        Prefer non-metadata XML files.
+        """
+        for href in hrefs:
+            lower_href = href.lower()
+            if lower_href.endswith(".xml") and not lower_href.endswith(
+                "assessment_meta.xml"
+            ):
+                return href
+        for href in hrefs:
+            if href.lower().endswith(".xml"):
+                return href
+        return hrefs[0] if hrefs else None
+
+    @staticmethod
+    def _select_metadata_xml_href(hrefs):
+        """
+        Select the metadata XML href from a list of resource files.
+        Prefer assessment_meta.xml.
+        """
+        for href in hrefs:
+            if href.lower().endswith("assessment_meta.xml"):
+                return href
+        for href in hrefs:
+            lower_href = href.lower()
+            if lower_href.endswith(".xml") and "meta" in lower_href:
+                return href
+        for href in hrefs:
+            if href.lower().endswith(".xml"):
+                return href
+        return hrefs[0] if hrefs else None
 
     @staticmethod
     def unzip_file(zip_path, extract_to):
@@ -96,16 +133,27 @@ class FileProcessor:
                 if "imsqti_xml" not in resource_type:
                     continue
 
-                quiz_href = FileProcessor._get_resource_file_href(resource)
-                dependency = resource.find("dependency")
-                dependency_href = None
-                if dependency is not None:
+                quiz_hrefs = FileProcessor._get_resource_file_hrefs(resource)
+                quiz_href = FileProcessor._select_quiz_xml_href(quiz_hrefs)
+
+                dependency_hrefs = []
+                for dependency in resource.findall("dependency"):
                     dep_id = dependency.get("identifierref")
                     dep_resource = resources_by_id.get(dep_id)
-                    if dep_resource is not None:
-                        dependency_href = FileProcessor._get_resource_file_href(
-                            dep_resource
-                        )
+                    if dep_resource is None:
+                        continue
+                    dependency_hrefs.extend(
+                        FileProcessor._get_resource_file_hrefs(dep_resource)
+                    )
+
+                dependency_href = FileProcessor._select_metadata_xml_href(
+                    dependency_hrefs
+                )
+
+                # Fallback for exports where metadata is bundled directly with
+                # quiz XML instead of listed as a dependency resource.
+                if dependency_href is None:
+                    dependency_href = FileProcessor._select_metadata_xml_href(quiz_hrefs)
 
                 if quiz_href and dependency_href:
                     quiz_pairs.append((quiz_href, dependency_href))

--- a/src/qti2txt/processors.py
+++ b/src/qti2txt/processors.py
@@ -33,9 +33,18 @@ class NamespaceStripper:
             tree.write(output_file)
         except ET.ParseError as e:
             logger.error(f"Issue parsing error: {e}")
+            raise Qti2txtError(f"Could not parse XML file: {input_file}") from e
 
 
 class FileProcessor:
+    @staticmethod
+    def _get_resource_file_href(resource):
+        """Return the first file href for a resource, if present."""
+        resource_file = resource.find("file")
+        if resource_file is None:
+            return None
+        return resource_file.get("href")
+
     @staticmethod
     def unzip_file(zip_path, extract_to):
         """QTI file comes as zip so let's unzip the file to the specified directory."""
@@ -44,7 +53,7 @@ class FileProcessor:
 
     @staticmethod
     def get_resource_hrefs(manifest_path):
-        """Get the href attributes from the first and second resources in the manifest."""
+        """Get `(quiz_xml_href, metadata_xml_href)` tuples from a manifest."""
         # open the imsmanifest.xml file
         with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
             tmp_file_path = tmp_file.name
@@ -71,29 +80,45 @@ class FileProcessor:
 
             # Find resources
             resources = root.findall(".//resource")
-            if len(resources) < 2:
+            if len(resources) < 1:
                 raise Qti2txtError("The manifest does not contain enough resources.")
-            
 
-            # The manifest file will store quizzes in pairs. They need to be extracted. Extracted as a tuple (first_href, second_href)
+            resources_by_id = {}
+            for resource in resources:
+                resource_id = resource.get("identifier")
+                if resource_id:
+                    resources_by_id[resource_id] = resource
+
+            # Canvas marks actual quiz payload resources with imsqti_xml* types.
             quiz_pairs = []
-            for i in range(0, len(resources), 2):
-                if i + 1 < len(resources):  # check if there is pair
-                    # null checks
-                    first_file = resources[i].find("file")
-                    second_file = resources[i + 1].find("file")
+            for resource in resources:
+                resource_type = (resource.get("type") or "").lower()
+                if "imsqti_xml" not in resource_type:
+                    continue
 
-                    if first_file is not None and second_file is not None:
-                        first_href = first_file.get("href")
-                        second_href = second_file.get("href")
-                        quiz_pairs.append(
-                            (first_href, second_href)
-                        )  # appending as tuple
-                        logger.info(f"Here are the refs: {first_href}, {second_href}")
-                    else:
-                        logger.warning(
-                            "Missing files or refs in manifest file required for Quiz extraction"
+                quiz_href = FileProcessor._get_resource_file_href(resource)
+                dependency = resource.find("dependency")
+                dependency_href = None
+                if dependency is not None:
+                    dep_id = dependency.get("identifierref")
+                    dep_resource = resources_by_id.get(dep_id)
+                    if dep_resource is not None:
+                        dependency_href = FileProcessor._get_resource_file_href(
+                            dep_resource
                         )
+
+                if quiz_href and dependency_href:
+                    quiz_pairs.append((quiz_href, dependency_href))
+                    logger.info(f"Here are the refs: {quiz_href}, {dependency_href}")
+                else:
+                    logger.warning(
+                        "Skipping quiz resource due to missing quiz/dependency XML refs"
+                    )
+
+            if not quiz_pairs:
+                raise Qti2txtError(
+                    "No quiz XML resources were found in the manifest."
+                )
 
             return quiz_pairs
         finally:

--- a/src/qti2txt/qti2txt.py
+++ b/src/qti2txt/qti2txt.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from . config_logging import startup_logger, primary_logger
 import uuid 
 import time
+import shutil
+import urllib.parse
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +51,33 @@ def main():
             logger.warning(f"Could not find tmp files to delete")
         except Exception as e:
             logger.warning(f"Error deleting temporary files: {e}")
+
+    # Copy bundled Canvas assets so rewritten image links resolve for text2qti.
+    def copy_web_resources(tmp_folder_path, output_path):
+        source_dir = Path(tmp_folder_path) / "web_resources"
+        destination_dir = output_path / "web_resources"
+        if not source_dir.exists():
+            logger.info("No web_resources folder found in archive")
+            return
+        try:
+            shutil.copytree(source_dir, destination_dir, dirs_exist_ok=True)
+            # text2qti uses markdown parsing for local images; create encoded aliases
+            # for filenames with parentheses so markdown links can use %28/%29 paths.
+            for file_path in destination_dir.rglob("*"):
+                if not file_path.is_file():
+                    continue
+                name = file_path.name
+                if "(" not in name and ")" not in name:
+                    continue
+                encoded_name = urllib.parse.quote(name, safe=" -._")
+                if encoded_name == name:
+                    continue
+                encoded_path = file_path.with_name(encoded_name)
+                if not encoded_path.exists():
+                    shutil.copy2(file_path, encoded_path)
+            logger.info(f"Copied media assets to {destination_dir}")
+        except Exception as e:
+            logger.warning(f"Could not copy media assets from {source_dir}: {e}")
 
     # Init argparse
     def create_CLI():
@@ -130,6 +159,8 @@ def main():
         except Exception as e:
             logger.critical(f"Error unzipping QTI file: {e}")
             return
+
+        copy_web_resources(tmp_folder, output_dir)
 
         # Get manifest file
         manifest_file = "imsmanifest.xml"

--- a/src/qti2txt/qti2txt.py
+++ b/src/qti2txt/qti2txt.py
@@ -158,7 +158,10 @@ def main():
             output_dir.mkdir(parents=True, exist_ok=True)
             logger.info(f"Output directory created at {output_dir.resolve()}")
         except Exception as e:
-            logger.warning(f"Could not create output directory {output_dir}: {e}")
+            logger.critical(f"Could not create output directory {output_dir}: {e}")
+            raise Qti2txtError(
+                f"Could not create output directory {output_dir}"
+            ) from e
     else:
         # Default to current working directory if no output path is specified
         output_dir = Path.cwd()
@@ -180,12 +183,14 @@ def main():
 
         # Get manifest file
         manifest_file = "imsmanifest.xml"
-        if not manifest_file:
-            logger.critical(
-                "No quiz manifests found in the zip file. Your QTI file should have a file named 'imsmanifest.xml."
-            )
-            return
         manifest_path = Path(tmp_folder) / manifest_file
+        if not manifest_path.is_file():
+            logger.critical(
+                "No quiz manifest found in the zip file. Expected file: imsmanifest.xml"
+            )
+            raise Qti2txtError(
+                "No quiz manifest found in the zip file. Expected file: imsmanifest.xml"
+            )
 
         # Get quiz pair hrefs from the manifest file
         quiz_pairs = FileProcessor.get_resource_hrefs(manifest_path)

--- a/src/qti2txt/qti2txt.py
+++ b/src/qti2txt/qti2txt.py
@@ -54,13 +54,29 @@ def main():
 
     # Copy bundled Canvas assets so rewritten image links resolve for text2qti.
     def copy_web_resources(tmp_folder_path, output_path):
-        source_dir = Path(tmp_folder_path) / "web_resources"
+        tmp_root = Path(tmp_folder_path)
         destination_dir = output_path / "web_resources"
-        if not source_dir.exists():
-            logger.info("No web_resources folder found in archive")
+        copy_sources = []
+
+        # Canvas exports commonly bundle assets in web_resources/.
+        source_web_resources = tmp_root / "web_resources"
+        if source_web_resources.exists():
+            copy_sources.append((source_web_resources, destination_dir))
+
+        # text2qti exports can bundle media directly as top-level images/ (or Images/).
+        for image_dir_name in ("images", "Images"):
+            source_images = tmp_root / image_dir_name
+            if source_images.exists():
+                copy_sources.append((source_images, destination_dir / image_dir_name))
+
+        if not copy_sources:
+            logger.info(
+                "No media asset folders found in archive (expected web_resources/ or images/)."
+            )
             return
         try:
-            shutil.copytree(source_dir, destination_dir, dirs_exist_ok=True)
+            for source_dir, target_dir in copy_sources:
+                shutil.copytree(source_dir, target_dir, dirs_exist_ok=True)
             # text2qti uses markdown parsing for local images; create encoded aliases
             # for filenames with parentheses so markdown links can use %28/%29 paths.
             for file_path in destination_dir.rglob("*"):
@@ -77,7 +93,7 @@ def main():
                     shutil.copy2(file_path, encoded_path)
             logger.info(f"Copied media assets to {destination_dir}")
         except Exception as e:
-            logger.warning(f"Could not copy media assets from {source_dir}: {e}")
+            logger.warning(f"Could not copy media assets into {destination_dir}: {e}")
 
     # Init argparse
     def create_CLI():


### PR DESCRIPTION
## Title
Harden manifest/output checks and improve multi-file dependency selection

## Summary
Tightens failure behavior around missing manifest/output path issues and improves selection of quiz and metadata XML when resources contain multiple `<file>` entries.

## Why
- Missing `imsmanifest.xml` previously did not hard-fail correctly.
- Some archives include multiple files/resource and metadata fallback patterns.

## Changes
- `src/qti2txt/qti2txt.py`
  - Raises `Qti2txtError` on output directory creation failure.
  - Explicitly checks `imsmanifest.xml` existence before manifest parsing.
 
- `src/qti2txt/processors.py`
  - Replaces single-file selection with multi-file selection helpers:
    - `_get_resource_file_hrefs()`
    - `_select_quiz_xml_href()`
    - `_select_metadata_xml_href()`
  - Supports metadata fallback when dependency resources are absent.
  
- `src/qti2txt/parsers.py`
  - Includes items directly under `assessment`.
  - Adds full-item fallback for unusual structures.

## Testing
- Verified behavior on archives with many quizzes and mixed resource declarations.
- Confirmed explicit failure on missing manifest cases.

## Risk
- Moderate due to manifest/resource selection logic changes.
